### PR TITLE
feat: create secondary navbar

### DIFF
--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -1,9 +1,14 @@
 <template>
-  <nav class="bg-sage-800 text-white w-full py-2 px-4 sm:px-6">
-    <div class="container mx-auto flex items-center justify-between">
-      <NavbarLogo :logoSrc="logoSrc" />
-      <NavbarMenu :links="links" menuClass="flex space-x-4" />
+  <nav class="bg-primary-800 text-white w-full pt-2">
+    <div class="flex items-center">
+      <router-link to="/">
+        <NavbarLogo :logoSrc="logoSrc" />
+      </router-link>
     </div>
+    <NavbarMenu
+      :links="links"
+      menuClass="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-7 bg-secondary-500"
+    />
   </nav>
 </template>
 
@@ -19,13 +24,13 @@ export default defineComponent({
     NavbarLogo,
     NavbarMenu,
   },
+
   data() {
     return {
       logoSrc,
       links: [
         { name: "Welcome", href: "/" },
         { name: "Self-assessment", href: "/self-assessment" },
-        { name: "Login", href: "/login" },
       ],
     };
   },

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -1,8 +1,8 @@
 <template>
-  <li class="navbar-item">
-    <a :href="link.href" class="text-white hover:text-gray-400">
+  <li class="mx-4">
+    <router-link :to="link.href" class="text-white hover:text-secondary-400">
       {{ link.name }}
-    </a>
+    </router-link>
   </li>
 </template>
 
@@ -20,8 +20,4 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
-.navbar-item {
-  margin: 0 1rem;
-}
-</style>
+<style scoped></style>

--- a/src/components/navbar/NavbarLogo.vue
+++ b/src/components/navbar/NavbarLogo.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex items-center">
-    <a class="navbar-item" href="/">
+  <div class="flex items-center ml-4">
+    <a href="/" class="block">
       <img
         :src="logoSrc"
-        alt="Logo"
-        class="logo w-24 h-auto sm:w-20 md:w-24 lg:w-28"
+        alt="EuFMD logo"
+        class="w-24 h-auto sm:w-20 md:w-24 lg:w-28"
       />
     </a>
   </div>

--- a/src/components/navbar/NavbarMenu.vue
+++ b/src/components/navbar/NavbarMenu.vue
@@ -1,7 +1,28 @@
 <template>
   <ul :class="['list-none p-0 m-0', menuClass]">
-    <li v-for="link in links" :key="link.name">
-      <a :href="link.href" class="hover:text-sage-300">{{ link.name }}</a>
+    <li
+      v-for="link in links"
+      :key="link.name"
+      class="col-span-1 flex items-center justify-center p-4 shadow-sm hover:bg-accent-500 focus:outline-none transition duration-300 ease-in-out"
+    >
+      <router-link
+        :to="link.href"
+        class="text-xl text-gray-100 hover:text-gray-50"
+        >{{ link.name }}</router-link
+      >
+    </li>
+    <li class="hidden lg:block lg:col-span-1 xl:col-span-3"></li>
+    <li
+      class="col-span-1 flex items-center justify-center p-4 shadow-sm hover:bg-accent-500 focus:outline-none transition duration-300 ease-in-out"
+    >
+      <router-link to="/login" class="text-xl text-gray-100 hover:text-gray-50"
+        >Login / Register
+      </router-link>
+    </li>
+    <li
+      class="col-span-1 flex items-center justify-center p-4 shadow-sm hover:bg-accent-500 focus:outline-none transition duration-300 ease-in-out"
+    >
+      Locale Switcher
     </li>
   </ul>
 </template>


### PR DESCRIPTION
# Description
This pull request adapts the `NavbarMenu` component to serve as a secondary navbar. All links now appear as menu tabs below the primary navigation bar. This enhancement ensures a clear and organized structure for additional navigation options.


## Changes Made
- Adapted the NavbarMenu component to function as a secondary navbar.
- Implemented dynamic link rendering based on props.
- Added a static "Login / Register" link.
- Ensured responsive design with hidden items on larger screens.

### Files Modified
src/components/navbar/NavbarMenu.vue
src/components/navbar/NavbarItem.vue
src/components/navbar/Navbar.vue
src/components/navbar/Logo.vue



#### How to Test
1. Run the application and navigate to the page containing the `NavbarMenu` component.
2. Verify that the menu displays the links passed via the links prop as tabs below the primary navbar.
3. Ensure the "Login / Register" item is displayed correctly.
4. Check the responsiveness of the menu on different screen sizes.

##### Additional Notes
Ensure that the links prop is passed correctly from the parent component.
The menuClass prop allows for additional styling flexibility.
